### PR TITLE
Add ability to ignore specific screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,25 @@ Make sure the class is only present during development. Here's an example of how
 
 ### Customization
 
-You can customize the position and styles in the `theme.debugScreens` section of your `tailwind.config.js` file.
+You can customize this plugin in the `theme.debugScreens` section of your `tailwind.config.js` file.
+
+#### Ignore screens
+
+To ignore a specific screen (for instance if you use [dark mode](https://tailwindcss.com/docs/breakpoints/#dark-mode)), add the screen name to the `ignore` configuration array.
+
+```js
+// tailwind.config.js
+module.exports = {
+  theme: {
+    debugScreens: {
+      ignore: ['dark'],
+    },
+  },
+  plugins: [
+    require('tailwindcss-debug-screens'),
+  ],
+}
+```
 
 #### Position
 
@@ -78,25 +96,6 @@ module.exports = {
         color: 'black',
         // ...
       },
-    },
-  },
-  plugins: [
-    require('tailwindcss-debug-screens'),
-  ],
-}
-```
-
-#### Ignoring Screens
-
-In some cases, like a custom screen media query, it can be helpful to ignore a specific screen. In that case
-add the screen name to the `ignore` configuration array.
-
-```js
-// tailwind.config.js
-module.exports = {
-  theme: {
-    debugScreens: {
-      ignore: ["custom-screen-name"],
     },
   },
   plugins: [

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Make sure the class is only present during development. Here's an example of how
 <body class="{{ devMode ? 'debug-screens' : '' }}">
 ```
 
-### Custimization
+### Customization
 
 You can customize the position and styles in the `theme.debugScreens` section of your `tailwind.config.js` file.
 

--- a/README.md
+++ b/README.md
@@ -85,3 +85,22 @@ module.exports = {
   ],
 }
 ```
+
+#### Ignoring Screens
+
+In some cases, like a custom screen media query, it can be helpful to ignore a specific screen. In that case
+add the screen name to the `ignore` configuration array.
+
+```js
+// tailwind.config.js
+module.exports = {
+  theme: {
+    debugScreens: {
+      ignore: ["custom-screen-name"],
+    },
+  },
+  plugins: [
+    require('tailwindcss-debug-screens'),
+  ],
+}
+```

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 module.exports = function ({ addComponents, theme }) {
   const screens = theme('screens');
   const userStyles = theme('debugScreens.style', {});
+  const ignore = theme("debugScreens.ignore", [])
 
   const defaultPosition = ['bottom', 'left'];
   const position = theme('debugScreens.position', defaultPosition);
@@ -24,7 +25,7 @@ module.exports = function ({ addComponents, theme }) {
     }, userStyles),
   };
 
-  Object.entries(screens).forEach(([screen]) => {
+  Object.entries(screens).filter(([screen]) => ignore.indexOf(screen) === -1).forEach(([screen]) => {
     components[`@screen ${screen}`] = {
       '.debug-screens::before': {
         content: `'screen: ${screen}'`,

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = function ({ addComponents, theme }) {
   const screens = theme('screens');
   const userStyles = theme('debugScreens.style', {});
-  const ignore = theme("debugScreens.ignore", [])
+  const ignoredScreens = theme('debugScreens.ignore', [])
 
   const defaultPosition = ['bottom', 'left'];
   const position = theme('debugScreens.position', defaultPosition);
@@ -25,13 +25,15 @@ module.exports = function ({ addComponents, theme }) {
     }, userStyles),
   };
 
-  Object.entries(screens).filter(([screen]) => ignore.indexOf(screen) === -1).forEach(([screen]) => {
-    components[`@screen ${screen}`] = {
-      '.debug-screens::before': {
-        content: `'screen: ${screen}'`,
-      },
-    };
-  });
+  Object.entries(screens)
+    .filter(([screen]) => !ignoredScreens.includes(screen))
+    .forEach(([screen]) => {
+      components[`@screen ${screen}`] = {
+        '.debug-screens::before': {
+          content: `'screen: ${screen}'`,
+        },
+      };
+    });
 
   addComponents(components);
 }


### PR DESCRIPTION
Hi, thanks for the great plugin, it works great!

I have a use case where I add a custom screen like this:
```js
module.exports = {
  theme: {
    extend: {
      screens: {
        dark: { raw: "(prefers-color-scheme: dark)" },
        reducedMotion: { raw: "(prefers-reduced-motion: reduce)" },
      },
    },
  },
}
```

In these cases the only thing I'll ever see with this plugin is either `screen: reducedMotion` or  `screen: dark`, doesn't matter what actual screen size the current one is (`sm`, `md`, ...).

This PR adds a configuration option to exclude specific screens:

```js
module.exports = {
  theme: {
    extend: {
      screens: {
        dark: { raw: "(prefers-color-scheme: dark)" },
        reducedMotion: { raw: "(prefers-reduced-motion: reduce)" },
      },
    },
    debugScreens: {
      ignore: ["dark", "motionless"],
    },
  },
}
```

Do you think this feature is a good fit here?

Thanks!