### PR TITLE
Sort the screens by their integer values

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,9 @@ module.exports = function ({ addComponents, theme }) {
 
   Object.entries(screens)
     .filter(([screen]) => !ignoredScreens.includes(screen))
+    .sort(([screenA, pixelA], [screenB, pixelB]) => {
+      return parseInt(pixelA) - parseInt(pixelB);
+    })
     .forEach(([screen]) => {
       components[`@screen ${screen}`] = {
         '.debug-screens::before': {


### PR DESCRIPTION
Currently, when extending the screens object with a new screen size on the lower end of screen width the debug output breaks.

**Minimal tailwind config to reproduce**

```
module.exports = {
    theme: {
        extend: {
            screens: {
                xs: '440px'
            },
            debugScreens: {
                position: ['top', 'left'],
            },
        },
    },
    plugins: [
        require('@tailwindcss/custom-forms'),
        require('tailwindcss-debug-screens'),
    ]
}
```

Using this config this output is generated:

<img width="191" alt="Bildschirmfoto 2020-11-06 um 23 01 04" src="https://user-images.githubusercontent.com/6104339/98418803-0107ea80-2084-11eb-96ae-f01d3bd67342.png">

As you can see, the `xs` screen will always win because it is added to the end of the `screens` object.

This pull request sorts the `screens` object by their respective integer value.

_This will not work when mixing, for example, `em` and `px` values._ But I don't think this will affect more users than it's affecting now.