### PR TITLE
Add ability to modify indicator prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,16 +104,16 @@ module.exports = {
 }
 ```
 
-#### Screen Prefix
+#### Prefix
 
-To modify the prefix for the screens, add the `indicatorPrefix` configuration.
+Modify the debug label prefix with the `prefix` configuration option.
 
 ```js
 // tailwind.config.js
 module.exports = {
   theme: {
     debugScreens: {
-      indicatorPrefix: 'screen: ',
+      prefix: 'screen: ',
     },
   },
   plugins: [

--- a/README.md
+++ b/README.md
@@ -103,3 +103,21 @@ module.exports = {
   ],
 }
 ```
+
+#### Screen Prefix
+
+To modify the prefix for the screens, add the `indicatorPrefix` configuration.
+
+```js
+// tailwind.config.js
+module.exports = {
+  theme: {
+    debugScreens: {
+      indicatorPrefix: 'screen: ',
+    },
+  },
+  plugins: [
+    require('tailwindcss-debug-screens'),
+  ],
+}
+```

--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ module.exports = function ({ addComponents, theme }) {
   const positionY = position[0] || defaultPosition[0];
   const positionX = position[1] || defaultPosition[1];
 
+  const indicatorPrefix = theme('debugScreens.indicatorPrefix', 'screens: ');
+
   const components = {
     '.debug-screens::before': Object.assign({
       position: 'fixed',
@@ -21,7 +23,7 @@ module.exports = function ({ addComponents, theme }) {
       backgroundColor: '#000',
       color: '#fff',
       boxShadow: '0 0 0 1px #fff',
-      content: `'screen: _'`,
+      content: `'${indicatorPrefix}_'`,
     }, userStyles),
   };
 
@@ -30,7 +32,7 @@ module.exports = function ({ addComponents, theme }) {
     .forEach(([screen]) => {
       components[`@screen ${screen}`] = {
         '.debug-screens::before': {
-          content: `'screen: ${screen}'`,
+          content: `'${indicatorPrefix}${screen}'`,
         },
       };
     });

--- a/index.js
+++ b/index.js
@@ -2,13 +2,12 @@ module.exports = function ({ addComponents, theme }) {
   const screens = theme('screens');
   const userStyles = theme('debugScreens.style', {});
   const ignoredScreens = theme('debugScreens.ignore', [])
+  const prefix = theme('debugScreens.prefix', 'screen: ');
 
   const defaultPosition = ['bottom', 'left'];
   const position = theme('debugScreens.position', defaultPosition);
   const positionY = position[0] || defaultPosition[0];
   const positionX = position[1] || defaultPosition[1];
-
-  const indicatorPrefix = theme('debugScreens.indicatorPrefix', 'screens: ');
 
   const components = {
     '.debug-screens::before': Object.assign({
@@ -23,7 +22,7 @@ module.exports = function ({ addComponents, theme }) {
       backgroundColor: '#000',
       color: '#fff',
       boxShadow: '0 0 0 1px #fff',
-      content: `'${indicatorPrefix}_'`,
+      content: `'${prefix}_'`,
     }, userStyles),
   };
 
@@ -32,7 +31,7 @@ module.exports = function ({ addComponents, theme }) {
     .forEach(([screen]) => {
       components[`@screen ${screen}`] = {
         '.debug-screens::before': {
-          content: `'${indicatorPrefix}${screen}'`,
+          content: `'${prefix}${screen}'`,
         },
       };
     });


### PR DESCRIPTION
I have the use case, that we don't need the `screens: ` prefix in the badge.
This PR adds a `indicatorPrefix` configuration option to modify the prefix.
So it could be set to empty by setting `indicatorPrefix` to `''` or it could be anything else like `width: `.
Example:
```
module.exports = {
  theme: {
    debugScreens: {
      indicatorPrefix: 'width: ',
    },
  },
}
```