### PR TITLE
Add support for Tailwind CSS 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   "homepage": "https://github.com/jorenvanhee/tailwindcss-debug-screens",
   "bugs": "https://github.com/jorenvanhee/tailwindcss-debug-screens/issues",
   "peerDependencies": {
-    "tailwindcss": "^1.0"
+    "tailwindcss": "^1.0 || ^2.0"
   }
 }


### PR DESCRIPTION
This change adds support for Tailwind CSS v2.0. Before this change, your package manager of choice would complain about an unmet peer dependency if it was used with Tailwind CSS 2 or newer.

The blog post and the upgrade guide do not mention any changes for plugins, I also verified the functionality in a project of mine. Everything still works as expected as far as I can see. :)

https://blog.tailwindcss.com/tailwindcss-v2
https://tailwindcss.com/docs/upgrading-to-v2